### PR TITLE
Darken weekend cells for better visibility

### DIFF
--- a/calendar.php
+++ b/calendar.php
@@ -79,7 +79,7 @@ td:empty {
 	color: #888;
 }
 .weekend {
-	background: #eee;
+	background: #d8d8d8;
 	font-weight: 400;
 }
 p {


### PR DESCRIPTION
The previous color (#eee) was too light to show up on my printer, and is not enough even on the web for users who struggle with low contrast.